### PR TITLE
Update peer dependency to use current version or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "stylelint-tape": "^2.0.0"
   },
   "peerDependencies": {
-    "stylelint": "^13.7.2"
+    "stylelint": ">=13"
   },
   "eslintConfig": {
     "extends": "dev",


### PR DESCRIPTION
```json
  "peerDependencies": {
    "stylelint": ">=13"
  },
```

This will ensure that you don't have to keep updating this yourself, and it allows users to choose their own recent major version. This skips the need for users to resolve the dependency conflicts manually in the future.

Thanks for creating this! :-)