### PR TITLE
Feature - handling props in values

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -211,6 +211,30 @@ module.exports = {
 			source: 'body { max-width: 250rem; }',
 			expect: 'body { max-inline-size: 250rem; }',
 			args: 'always'
+		}, {
+			source: 'body { transition-property: border-top-color; }',
+			expect: 'body { transition-property: border-block-start-color; }',
+			args: 'always'
+		}, {
+			source: 'body { will-change: padding-left; }',
+			expect: 'body { will-change: padding-inline-start; }',
+			args: 'always'
+		}, {
+			source: 'body { transition: width 1s, top 2s, left 3s; }',
+			expect: 'body { transition: inline-size 1s, inset-block-start 2s, inset-inline-start 3s; }',
+			args: 'always'
+		}, {
+			source: 'body { transition: width 1s, top 2s, left 3s; }',
+			expect: 'body { transition: inline-size 1s, inset-block-start 2s, inset-inline-end 3s; }',
+			args: ['always', { 'direction' : 'rtl' } ]
+		}, {
+			source: 'body { transition: width 1s, top 2s, left 3s; }',
+			expect: 'body { transition: width 1s, inset-block-start 2s, inset-inline-start 3s; }',
+			args: ['always', { 'except' : ['width'] } ]
+		}, {
+			source: 'body { will-change: padding-left; transition: width 1s, top 2s, left 3s; }',
+			warnings: 2,
+			args: 'always'
 		}
 	]
 };

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -3,6 +3,8 @@ const inline = {
 	end: { ltr: 'right', rtl: 'left' }
 }
 
+export const propsThatContainPropsInValue = /^(transition(-property)?|will-change)$/i;
+
 export const physical4Prop = [
 	[['top', 'left', 'bottom', 'right'], 'inset'],
 	[['margin-top', 'margin-left', 'margin-bottom', 'margin-right'], 'margin'],


### PR DESCRIPTION
#22 

The script loops through the maps listing of all properties and will make multiple replacements in a single string such as:
`transition: max-width 1s, padding-left 2s, margin-top 3s;` 
will recommend (or change to):
`transition: max-inline-size 1s, padding-inline-start 2s, margin-block-start 3s;` (for 'ltr' anyway)

I could only find 3 properties that would seem to fit this use case:
- transition
- transition-property
- will-change

If there are more, this is easy to update as the regex is stored in the `maps.js` file. By selecting only these nodes, I feel this one should run pretty lean instead of scanning all values for property names.