### PR TITLE
Safely parse CSS values

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -131,6 +131,11 @@ module.exports = {
 			args: "always",
 		},
 		{
+			source: "body { inset: calc(20px * 1) calc(30px * 1) calc(10px * 1); }",
+			expect: "body { inset-block: calc(20px * 1) calc(10px * 1); inset-inline: calc(30px * 1); }",
+			args: "always",
+		},
+		{
 			source: "body { margin: 20px 30px 10px 40px; }",
 			expect: "body { margin-block: 20px 10px; margin-inline: 40px 30px; }",
 			args: "always",

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import valueParser from 'postcss-value-parser';
 import stylelint from 'stylelint';
 import { physicalProp, physical2Prop, physicalShorthandProp, physical4Prop, physicalValue, migrationNoneSpec, propsThatContainPropsInValue } from './lib/maps';
 import { validateRuleWithProps } from './lib/validate';
@@ -111,7 +112,7 @@ export default stylelint.createPlugin(ruleName, (method, opts, context) => {
 				// validate or autofix shorthand properties that are not supported
 				physicalShorthandProp.forEach((prop) => {
 					validateRuleWithProps(node, [prop], physicalDecl => { // eslint-disable-line
-						let inputValues = physicalDecl.value.trim().split(' ');
+						let inputValues = valueParser(physicalDecl.value).nodes.filter(value => value.type !== 'space').map(value => valueParser.stringify(value));
 						if (
 							!isDeclAnException(physicalDecl, propExceptions) &&
 							inputValues.length !== 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "stylelint-use-logical-spec",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-use-logical-spec",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "CC0-1.0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.12.3",
         "@babel/preset-env": "^7.12.1",
@@ -3643,10 +3646,9 @@
       "dev": true
     },
     "node_modules/postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/postcss/node_modules/source-map": {
       "version": "0.6.1",
@@ -8107,10 +8109,9 @@
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "pre-commit": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "postcss-value-parser": "^4.2.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",


### PR DESCRIPTION
Uses [postcss-value-parser](https://github.com/TrySound/postcss-value-parser) which allows values to contain spaces (e.g. inside a calc() function).

I suspect more than can be done with this (e.g. what happens with comments?), but this should get around the issue I'm seeing where it throws an error (#28).
