### PR TITLE
Add experimental logical keyword

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -376,5 +376,34 @@ module.exports = {
 			warnings: 2,
 			args: "always",
 		},
+		{
+		  source: "body { margin: 20px 30px 10px 40px; }",
+		  expect: "body { margin: logical 20px 30px 10px 40px; }",
+		  args: ["always", {logicalKeyword: true}],
+		  warnings: 0,
+		},
+		{
+		  source: "body { margin: logical 20px 30px 10px 40px; }",
+		  args: ["always", {logicalKeyword: true}],
+		  warnings: 0,
+		},
+		{
+		  source: "body { margin: 20px 30px 10px 40px; }",
+		  expect: "body { margin: logical 20px 40px 10px 30px; }",
+		  args: ["always", { direction: "rtl", logicalKeyword: true }],
+		  warnings: 0,
+		},
+		{
+		  source: "body { margin: calc(20px * 1) calc(30px * 1) calc(40px * 1) calc(10px * 1); }",
+		  expect: "body { margin: logical calc(20px * 1) calc(10px * 1) calc(40px * 1) calc(30px * 1); }",
+		  args: ["always", { direction: "rtl", logicalKeyword: true }],
+		  warnings: 0,
+		},
+		{
+		  source: "body { padding: 20px 0; }",
+		  expect: "body { padding: logical 20px 0; }",
+		  args: ["always", {logicalKeyword: true}],
+		  warnings: 0,
+		},
 	],
 };

--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ properties and values should be reported or autofixed.
 }
 ```
 
+### logicalKeyword
+
+The `logicalKeyword` option enables experimental `logical` keyword for `margin` and `padding` physical properties.
+
+```js
+{
+  "rules": {
+    "liberty/use-logical-spec": ["always", { "logicalKeyword": true }]
+  }
+}
+```
+
 ## Property and Value Mapping
 
 Assuming _left to right_ directionality:

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -13,6 +13,8 @@ export const physical4Prop = [
 
 export const physicalShorthandProp = ['inset', 'margin', 'padding'];
 
+export const physicalShorthandPropLogicalKeyword = ['margin', 'padding'];
+
 export const physical2Prop = dir => [
 	[['top', 'bottom'], 'inset-block'],
 	[[inline.start[dir], inline.end[dir]], 'inset-inline'],


### PR DESCRIPTION
Add option to use `logical` keyword for `margin` and `padding`.

Its can be used in future and with [postcss-logical](https://www.npmjs.com/package/postcss-logical), which supports logical keyword.