### PR TITLE
feat: add supporting for css-in-js

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -385,6 +385,11 @@ module.exports = {
 			source: "max-width: 250rem;",
 			expect: "max-inline-size: 250rem;",
 			args: "always",
+		},
+		{
+			source: "padding: ${props => props ? 1 : 2};",
+			warnings: 1,
+			args: "always",
 		},		
 	],
 };

--- a/.tape.js
+++ b/.tape.js
@@ -376,5 +376,15 @@ module.exports = {
 			warnings: 2,
 			args: "always",
 		},
+		{
+			source: "margin-start: 0;",
+			expect: "margin-block-start: 0;margin-inline-start: 0;",
+			args: "always",
+		},
+		{
+			source: "max-width: 250rem;",
+			expect: "max-inline-size: 250rem;",
+			args: "always",
+		},		
 	],
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,11 +1,13 @@
 export const validateRuleWithProps = (root, props, fn) => {
+	// For supporting css-in-js
+	const { nodes = [root] } = root;
 	// conditionally walk nodes with children
-	if (root.nodes && root.nodes.length) {
+	if (nodes && nodes.length) {
 		const args = [];
 
 		const hasProps = props.every(prop => {
-			const declIndex = root.nodes.findIndex(child => child.type === 'decl' && child.prop === prop);
-			const decl = root.nodes[declIndex];
+			const declIndex = nodes.findIndex(child => child.type === 'decl' && child.prop === prop);
+			const decl = nodes[declIndex];
 
 			if (decl) {
 				args.push(decl, declIndex);


### PR DESCRIPTION
Currently it's just semi-support in css-in-js


Given:
```ts
import { css } from "@emotion/react";

export function setBaseContainerLayout() {
  return css`
    margin: 0 auto;
    box-sizing: border-box;
    a {
       margin: 0 auto;
    }
  `;
}
```

Expected:
```ts
import { css } from "@emotion/react";

export function setBaseContainerLayout() {
  return css`
    margin-block: 0;
    margin-inline: auto;
    box-sizing: border-box;
    a {
      margin-block: 0;
      margin-inline: auto;
    }
  `;
}
```

Actual:
```ts
import { css } from "@emotion/react";

export function setBaseContainerLayout() {
  return css`
    margin: 0 auto;
    box-sizing: border-box;
    a {
      margin-block: 0;
      margin-inline: auto;
    }
  `;
}
```