### PR TITLE
feat: use custom function for splitting CSS values

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -376,5 +376,20 @@ module.exports = {
 			warnings: 2,
 			args: "always",
 		},
+		{
+			source: "body { margin: 20px; }",
+			expect: "body { margin: 20px; }",
+			args: "always",
+		},
+		{
+			source: "body { margin: map-get($spacers, 4); }",
+			expect: "body { margin: map-get($spacers, 4); }",
+			args: "always",
+		},
+		{
+			source: "body { margin: map-get($spacers, 4) map-get($spacers, 2); }",
+			expect: "body { margin-block: map-get($spacers, 4); margin-inline: map-get($spacers, 2); }",
+			args: "always",
+		},
 	],
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-import valueParser from 'postcss-value-parser';
 import stylelint from 'stylelint';
 import { physicalProp, physical2Prop, physicalShorthandProp, physical4Prop, physicalValue, migrationNoneSpec, propsThatContainPropsInValue } from './lib/maps';
 import { validateRuleWithProps } from './lib/validate';
+import { cssValueSplit } from './lib/value-split';
 import ruleName from './lib/rule-name';
 import messages from './lib/messages';
 import walk from './lib/walk';
@@ -112,7 +112,7 @@ export default stylelint.createPlugin(ruleName, (method, opts, context) => {
 				// validate or autofix shorthand properties that are not supported
 				physicalShorthandProp.forEach((prop) => {
 					validateRuleWithProps(node, [prop], physicalDecl => { // eslint-disable-line
-						let inputValues = valueParser(physicalDecl.value).nodes.filter(value => value.type !== 'space').map(value => valueParser.stringify(value));
+						const inputValues = cssValueSplit(physicalDecl.value);
 						if (
 							!isDeclAnException(physicalDecl, propExceptions) &&
 							inputValues.length !== 1
@@ -284,7 +284,7 @@ const convertShorthandValues = (input, dir) => {
 };
 
 const optimizeCssValues = (value) => {
-	let values = value.split(' ');
+	const values = cssValueSplit(value);
 	if (values.length === 2 && values[0] === values[1]) {
 		return values[0];
 	}

--- a/lib/value-split.js
+++ b/lib/value-split.js
@@ -1,0 +1,58 @@
+export const cssValueSplit = (value) => {
+	const ret = [];
+	const stack = [];
+
+	let part = '';
+	let esc = false;
+	let q = '';
+
+	for (let i = 0; i < value.length; i++) {
+		const c = value[i];
+
+		if (esc) {
+			esc = false;
+		} else if (c === '\\') {
+			esc = true;
+		} else if (q) {
+			if (c === q) {
+				q = '';
+			}
+		} else if (c === '\'' || c === '"') {
+			q = c;
+		} else if (c === ' ' && stack.length === 0) {
+			if (part) {
+				ret.push(part);
+			}
+			part = '';
+			continue;
+
+		} else if (c === '(') {
+			stack.push(')');
+		} else if (c === '{') {
+			stack.push('}');
+		} else if (c === '[') {
+			stack.push(']');
+		} else if (stack.length && c === stack[stack.length - 1]) {
+			stack.length--;
+		}
+
+		part += c;
+	}
+
+	if (part) {
+		ret.push(part);
+	}
+
+	return ret;
+}
+
+// console.log(cssValueSplit('3px  0 5px'));
+// -> [ '3px', '0', '5px' ]
+// console.log(cssValueSplit('3px calc(--bla, 0) 5px'));
+// -> [ '3px', 'calc(--bla, 0)', '5px' ]
+// console.log(cssValueSplit('3px map-get($spacers, 2) 5px'));
+// -> [ '3px', 'map-get($spacers, 2)', '5px' ]
+// console.log(cssValueSplit('-#{map-get($spacers, 2)} #{map-get($spacers, 3)} 5px'));
+// -> [ '-#{map-get($spacers, 2)}', '#{map-get($spacers, 3)}', '5px' ]
+// console.log(cssValueSplit('-#{function("something ) else\')\\" bla", 2)} #{map-get($spacers, 3)} 5px'));
+// [ `-#{function("something ) else')\\" bla", 2)}`, '#{map-get($spacers, 3)}', '5px' ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "stylelint-use-logical-spec",
       "version": "4.1.0",
       "license": "CC0-1.0",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.12.3",
         "@babel/preset-env": "^7.12.1",
@@ -3648,7 +3645,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/postcss/node_modules/source-map": {
       "version": "0.6.1",
@@ -8111,7 +8109,8 @@
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "pre-commit": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "dependencies": {
-    "postcss-value-parser": "^4.2.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",


### PR DESCRIPTION
- postcss-value-parser doesn't support interpolations yet (e.g. SCSS `#{}`)
- AST is not needed

See #28